### PR TITLE
fix(#26): ignore subdirectories in assess_size_codebase()

### DIFF
--- a/R/documentation_metrics.R
+++ b/R/documentation_metrics.R
@@ -231,6 +231,7 @@ assess_size_codebase <- function(pkg_source_path) {
   
     # create character vector of function files
     files <- list.files(path = file.path(pkg_source_path, "R"), full.names = T)
+    files <- files[!dir.exists(files)]
     
     # define the function for counting code base
     count_lines <- function(x){

--- a/tests/testthat/test-documentation_metrics.R
+++ b/tests/testthat/test-documentation_metrics.R
@@ -1849,3 +1849,26 @@ test_that("assess code base size for large package works correctly", {
   
 })
 
+
+test_that("assess_size_codebase handles subdirectories in R/ folder (#26)", {
+  # Create a temporary package structure with a subdirectory inside R/
+  pkg_dir <- tempfile("testpkg")
+  r_dir <- file.path(pkg_dir, "R")
+  dir.create(r_dir, recursive = TRUE)
+
+  # Create a regular R file
+  writeLines(c("# A function", "foo <- function() {", "  1 + 1", "}"), 
+             file.path(r_dir, "foo.R"))
+
+  # Create a subdirectory inside R/ (like vdiffr's R/svglite)
+  dir.create(file.path(r_dir, "subdir"))
+
+  # This should not error
+  result <- assess_size_codebase(pkg_dir)
+
+  expect_true(is.numeric(result))
+  expect_true(result > 0)
+
+  # Clean up
+  unlink(pkg_dir, recursive = TRUE)
+})


### PR DESCRIPTION
## Summary
Fixes #26 — `risk_assess_pkg()` fails to assess packages (like `vdiffr`) that contain subdirectories inside their `R/` folder.

## Cause & Fix
The `assess_size_codebase()` function calls `list.files()` on the pkg's `R/` directory without filtering out subdirectories. It then passes every result to `readLines()`, which throws an `"is a directory"` error.

I added a one-line fix: `files <- files[!dir.exists(files)]` to ensure only regular files are parsed.

## Testing
- Extended `test-documentation_metrics.R` with a new unit test covering the subdirectory scenario.
- All 180 tests pass (`devtools::test()`).
