### PR TITLE
Fix: Return NA_character_ instead of NULL for missing maintainer (#25)

### DIFF
--- a/R/documentation_metrics.R
+++ b/R/documentation_metrics.R
@@ -109,7 +109,7 @@ assess_description_file_elements <- function(pkg_name, pkg_source_path) {
   has_maintainer <- desc::desc_get_author(role = "cre",
                                        file = pkg_source_path)
   if (length(has_maintainer) == 0) {
-    has_maintainer <-  NULL
+    has_maintainer <- NA_character_
     message(glue::glue("{pkg_name} does not have a maintainer"))
   } else {
     message(glue::glue("{pkg_name} has a maintainer"))
@@ -359,7 +359,7 @@ get_pkg_author <- function(pkg_name, pkg_source_path) {
     pkg_creator <- desc::desc_get_author(role = "cre",
                                          file = pkg_desc_path)
     
-    if (length(pkg_creator) == 0) pkg_creator <-  NULL
+    if (length(pkg_creator) == 0) pkg_creator <- NA_character_
 
     # check for package funder
     pkg_fnd <- desc::desc_get_author(role = "fnd",

--- a/tests/testthat/test-documentation_metrics.R
+++ b/tests/testthat/test-documentation_metrics.R
@@ -168,7 +168,7 @@ test_that("get_pkg_author handles missing creator and author", {
   
   result <- get_pkg_author(pkg_name, pkg_source_path)
   
-  expect_null(result$maintainer)
+  expect_identical(result$maintainer, NA_character_)
   expect_null(result$authors)
   expect_null(result$funder)
 })


### PR DESCRIPTION
Fixes #25.

When a package lacks a maintainer (like `mockpkg` in `tests/`), `get_pkg_author` and `assess_description_file_elements` previously returned `NULL`. This threw off results formatting since other missing fields returned `NA_character_`.

By changing `NULL` to `NA_character_`, missing maintainer values become structurally consistent with missing URLs, authors, and bugs fields. 

Also updated `test-documentation_metrics.R` to properly expect `NA_character_` when no maintainer is found.